### PR TITLE
Backport updates from application-services gradle files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+// This is based off:
+// https://github.com/mozilla/application-services/blob/84e077d1534dc287bbd472da658ce22eea5af032/build.gradle
 
 buildscript {
     ext.kotlin_version = '1.3.30'
@@ -65,97 +71,8 @@ task clean(type: Delete) {
 // { ... }`, to avoid issues with importing.
 import com.sun.jna.Platform as DefaultPlatform
 
-// If this is `null`, we use libs from the source directory.
-// Check if there are any changes to `libs` since `master`, and if not,
-// use the sha to download the artifacts from taskcluster.
-//
-// Note we pass the path to the git-dir so that this still works when
-// used as a dependency substitution from e.g. android-components.
-
-// TODO: git is not available on all systems
-ext.libsGitSha = "5963858cbc4a55b295dd69efd97bc043259241c5"
-//ext.libsGitSha = "git --git-dir=${rootProject.rootDir}/.git diff --name-only master -- :/libs".execute().text.allWhitespace ?
-//                 "git --git-dir=${rootProject.rootDir}/.git rev-parse HEAD:libs".execute().text.trim() : null
-
-// Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
-// downloaded libs.
-def useDownloadedLibs = !System.getenv('CI') && ext.libsGitSha != null
-
-if (useDownloadedLibs) {
-    task downloadAndroidLibs(type: Download) {
-        src "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.android.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
-        dest new File(buildDir, "libs.android.${rootProject.ext.libsGitSha}.tar.gz")
-
-        doFirst {
-            if (it.dest.exists()) {
-                throw new StopExecutionException("File to download already exists: ${it.dest.path}")
-            }
-        }
-        overwrite true
-    }
-
-    task untarAndroidLibs(dependsOn: downloadAndroidLibs, type: Copy) {
-        from tarTree(downloadAndroidLibs.dest)
-        into rootProject.buildDir
-    }
-
-    task downloadDesktopLibs(type: Download) {
-        src {
-            switch (DefaultPlatform.RESOURCE_PREFIX) {
-                case 'darwin':
-                    return "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.desktop.macos.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
-                case 'linux-x86-64':
-                    return "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.desktop.linux.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
-                case 'win32-x86-64':
-                    return "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.desktop.win32-x86-64.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
-                default:
-                    throw new GradleException("Unknown host platform '${DefaultPlatform.RESOURCE_PREFIX}'.  " +
-                                              "Set `ext.libsGitSha = null` in ${rootProject.rootDir}/build.gradle and build your own libs.  " +
-                                              "If you don't want to build your own libs for Android, you can untar\n\n${downloadAndroidLibs.src}\n\nat top-level to populate `libs/android/`.  " +
-                                              "You'll need build your own libs for your host platform in order to be able to build and run unit tests.")
-            }
-        }
-
-        dest {
-            switch (DefaultPlatform.RESOURCE_PREFIX) {
-                case 'darwin':
-                    return new File(buildDir, "libs.desktop.macos.${rootProject.ext.libsGitSha}.tar.gz")
-                case 'linux-x86-64':
-                    return new File(buildDir, "libs.desktop.linux.${rootProject.ext.libsGitSha}.tar.gz")
-                case 'win32-x86-64':
-                    return new File(buildDir, "libs.desktop.win32-x86-64.${rootProject.ext.libsGitSha}.tar.gz")
-                default:
-                    throw new GradleException("Unknown host platform '${DefaultPlatform.RESOURCE_PREFIX}'.  " +
-                                              "Set `ext.libsGitSha = null` in ${rootProject.rootDir}/build.gradle and build your own libs.")
-            }
-        }
-
-        doFirst {
-            if (it.dest.exists()) {
-                throw new StopExecutionException("File to download already exists: ${it.dest.path}")
-            }
-        }
-        overwrite true
-    }
-
-    task untarDesktopLibs(dependsOn: downloadDesktopLibs, type: Copy) {
-        from tarTree(downloadDesktopLibs.dest)
-        into rootProject.buildDir
-    }
-
-    // TODO: This attempts to download pre-built libraries from taskcluster. This is
-    // not currently supported for glean-core.
-    /*
-    subprojects { project ->
-        afterEvaluate {
-            android.libraryVariants.all { v ->
-                def task = v.preBuild
-                task.dependsOn(rootProject.untarAndroidLibs)
-                task.dependsOn(rootProject.untarDesktopLibs)
-            }
-        }
-    }*/
-}
+//  application-services has hooks to download external dependencies here. This
+//  has been removed since `glean-core` doesn't have any external dependencies for now.
 
 Properties localProperties = null
 if (file('local.properties').canRead()) {
@@ -212,8 +129,6 @@ switch (DefaultPlatform.RESOURCE_PREFIX) {
         ext.rustTargets += 'win32-x86-64-msvc'
         break
 }
-
-def libsRootDir = useDownloadedLibs ? rootProject.buildDir : rootProject.rootDir
 
 subprojects {
     apply plugin: 'digital.wup.android-maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,8 @@
 
 buildscript {
     ext.kotlin_version = '1.3.30'
-
-    ext.library = [
-        version: '0.16.1'
-    ]
+    ext.android_components_version = '0.50.0'
+    ext.jna_version = '5.2.0'
 
     ext.build = [
         compileSdkVersion: 27,
@@ -25,14 +23,13 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'digital.wup:android-maven-publish:3.6.2'
 
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.0'
+        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.1'
 
         // Yes, this is unusual.  We want to access some host-specific
         // computation at build time.
-        classpath 'net.java.dev.jna:jna:4.5.2'
+        classpath "net.java.dev.jna:jna:$jna_version"
 
         // Downloading libs/ archives from Taskcluster.
         classpath 'de.undercouch:gradle-download-task:3.4.3'
@@ -44,30 +41,18 @@ buildscript {
     }
 }
 
+plugins {
+    id("io.gitlab.arturbosch.detekt").version("1.0.0-RC14")
+}
+
 apply plugin: 'de.undercouch.download'
 
 allprojects {
     repositories {
         google()
         jcenter()
-    }
-}
-
-subprojects {
-    apply plugin: 'digital.wup.android-maven-publish'
-
-    // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to
-    // `./gradlew publish`) and also `./gradlew publishToProjectBuildDir`.
-    publishing {
-        repositories {
-            maven {
-                name = "rootProjectBuildDir"
-                url "file://${project.rootProject.buildDir}/maven"
-            }
-            maven {
-                name = "projectBuildDir"
-                url "file://${project.buildDir}/maven"
-            }
+        maven {
+            url "https://maven.mozilla.org/maven2"
         }
     }
 }
@@ -80,15 +65,23 @@ task clean(type: Delete) {
 // { ... }`, to avoid issues with importing.
 import com.sun.jna.Platform as DefaultPlatform
 
-// This is the output `git rev-parse HEAD:libs`.  We could discover this automatically, but
-// let's keep things simple and bump this manually for a while.  If and when we grow SNAPSHOT
-// support on maven.mozilla.org, we can invest in a better approach for versioning these
-// prerequisite libraries.
+// If this is `null`, we use libs from the source directory.
+// Check if there are any changes to `libs` since `master`, and if not,
+// use the sha to download the artifacts from taskcluster.
 //
-// Set this to `= null` in order to use libs from the source directory.
-ext.libsGitSha = '3c98949838e2df00517a0f60df82a73d4f3d7660'
+// Note we pass the path to the git-dir so that this still works when
+// used as a dependency substitution from e.g. android-components.
 
-if (rootProject.ext.libsGitSha != null) {
+// TODO: git is not available on all systems
+ext.libsGitSha = "5963858cbc4a55b295dd69efd97bc043259241c5"
+//ext.libsGitSha = "git --git-dir=${rootProject.rootDir}/.git diff --name-only master -- :/libs".execute().text.allWhitespace ?
+//                 "git --git-dir=${rootProject.rootDir}/.git rev-parse HEAD:libs".execute().text.trim() : null
+
+// Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
+// downloaded libs.
+def useDownloadedLibs = !System.getenv('CI') && ext.libsGitSha != null
+
+if (useDownloadedLibs) {
     task downloadAndroidLibs(type: Download) {
         src "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.android.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
         dest new File(buildDir, "libs.android.${rootProject.ext.libsGitSha}.tar.gz")
@@ -150,30 +143,134 @@ if (rootProject.ext.libsGitSha != null) {
         into rootProject.buildDir
     }
 
+    // TODO: This attempts to download pre-built libraries from taskcluster. This is
+    // not currently supported for glean-core.
+    /*
+    subprojects { project ->
+        afterEvaluate {
+            android.libraryVariants.all { v ->
+                def task = v.preBuild
+                task.dependsOn(rootProject.untarAndroidLibs)
+                task.dependsOn(rootProject.untarDesktopLibs)
+            }
+        }
+    }*/
+}
+
+Properties localProperties = null
+if (file('local.properties').canRead()) {
+    localProperties = new Properties()
+    localProperties.load(file('local.properties').newDataInputStream())
+    logger.lifecycle('Local configuration: loaded local.properties')
+}
+
+// For non-megazord builds, don't do a release build unless we explicitly want
+// it (e.g. in CI, or if specified in local.properties). This avoids some cases
+// where two builds of some crates are required when they wouldn't otherwise be,
+// as well as improving build times for local development.
+ext.nonMegazordProfile = "debug"
+// Additionally, we require `--locked` in CI, but not for local builds.
+// Unlike the above, this can't be overridden by `local.properties` (mainly
+// because doing so seems pointless, not for any security reason)
+ext.extraCargoBuildArguments = []
+
+if (System.getenv("CI")) {
+    // Note: CI can still override this (and does for PRs), this
+    // is just the default
+    ext.nonMegazordProfile = "release"
+    ext.extraCargoBuildArguments = ["--locked"]
+}
+
+if (localProperties != null) {
+    String localNonMegazordProfile = localProperties.getProperty(
+        "application-services.nonmegazord-profile")
+    if (localNonMegazordProfile != null) {
+        ext.nonMegazordProfile = localNonMegazordProfile
+    }
+}
+
+// The Cargo targets to invoke.  The mapping from short name to target
+// triple is defined by the `rust-android-gradle` plugin.
+// They can be overwritten in `local.properties` by the `rust.targets`
+// attribute.
+ext.rustTargets = [
+    'arm',
+    'arm64',
+    'x86_64',
+    'x86',
+]
+
+// Generate libs for our current platform so we can run unit tests.
+switch (DefaultPlatform.RESOURCE_PREFIX) {
+    case 'darwin':
+        ext.rustTargets += 'darwin'
+        break
+    case 'linux-x86-64':
+        ext.rustTargets += 'linux-x86-64'
+        break
+    case 'win32-x86-64':
+        ext.rustTargets += 'win32-x86-64-msvc'
+        break
+}
+
+def libsRootDir = useDownloadedLibs ? rootProject.buildDir : rootProject.rootDir
+
+subprojects {
+    apply plugin: 'digital.wup.android-maven-publish'
+
+    // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to
+    // `./gradlew publish`) and also `./gradlew publishToProjectBuildDir`.
+    publishing {
+        repositories {
+            maven {
+                name = "rootProjectBuildDir"
+                url "file://${project.rootProject.buildDir}/maven"
+            }
+            maven {
+                name = "projectBuildDir"
+                url "file://${project.buildDir}/maven"
+            }
+        }
+    }
 }
 
 // Configure some environment variables, per toolchain, that will apply during
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).
 ext.cargoExec = { spec, toolchain ->
-    // Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
-    // downloaded libs.
-    def libsRootDir = (System.getenv('CI') || ext.libsGitSha == null) ? rootProject.rootDir : rootProject.buildDir
+    // Intentionally empty. Removing this block breaks build.
 }
 
-task zipMavenArtifacts(type: Zip) {
-    from "${project.buildDir}/maven"
+detekt {
+    // The version number is duplicated, please refer to plugins block for more details
+    toolVersion = "1.0.0-RC14"
+    input = files("${projectDir}/glean-core", "${projectDir}/samples/android", "buildSrc")
+    filters = ".*test.*,.*/resources/.*,.*/tmp/.*,.*/build/.*"
+    config = files("${projectDir}/.detekt.yml")
+    failFast = false
+    reports {
+        xml.enabled = false
+    }
+}
 
-    include '**/*.aar'
-    include '**/*.jar'
-    include '**/*.pom'
-    include '**/*.md5'
-    include '**/*.sha1'
+configurations {
+    ktlint
+}
 
-    // Metadata is generated by maven.mozilla.org directly
-    exclude '**/*maven-metadata.xml*'
+dependencies {
+    ktlint "com.github.shyiko:ktlint:0.31.0"
+}
 
-    archiveName "target.maven.zip"
-    includeEmptyDirs = false
-    destinationDir(file("${project.buildDir}"))
+task ktlint(type: JavaExec, group: "verification") {
+    description = "Check Kotlin code style."
+    classpath = configurations.ktlint
+    main = "com.github.shyiko.ktlint.Main"
+    args "${projectDir}/glean-core/**/*.kt", "${projectDir}/samples/android/**/*.kt", "buildSrc/**/*.kt", "!**/build"
+}
+
+task ktlintFormat(type: JavaExec, group: "formatting") {
+    description = "Fix Kotlin code style deviations."
+    classpath = configurations.ktlint
+    main = "com.github.shyiko.ktlint.Main"
+    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build"
 }

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// This is based off:
+// https://github.com/mozilla/application-services/blob/c40e2ccb422cf4af9ffdf095149cec34de1d4bef/components/fxa-client/android/build.gradle
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }

--- a/glean-core/android/build.gradle
+++ b/glean-core/android/build.gradle
@@ -11,8 +11,6 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-import org.apache.tools.ant.taskdefs.condition.Os
-
 /*
  * This defines the location of the JSON schema used to validate the pings
  * created during unit testing.
@@ -21,8 +19,12 @@ import org.apache.tools.ant.taskdefs.condition.Os
 String GLEAN_PING_SCHEMA_GIT_HASH = "64b852c"
 String GLEAN_PING_SCHEMA_URL = "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/$GLEAN_PING_SCHEMA_GIT_HASH/schemas/glean/baseline/baseline.1.schema.json"
 
+// Set configuration for the glean_parser
+ext.allowGleanInternal = true
+ext.gleanNamespace = "mozilla.telemetry.glean"
+
 android {
-    compileSdkVersion 27
+    compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.build['minSdkVersion']
@@ -46,20 +48,14 @@ android {
     }
 
     sourceSets {
+        main.jniLibs.srcDirs += "$buildDir/nativeLibs/android"
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        test.resources.srcDirs += "$buildDir/nativeLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
-
-// Set configuration for the glean_parser
-ext.allowGleanInternal = true
-ext.gleanNamespace = "mozilla.telemetry.glean"
 
 configurations {
     withoutLib {
@@ -67,20 +63,9 @@ configurations {
 }
 
 afterEvaluate {
-    // The `cargoBuild` task isn't available until after evaluation.
-    android.libraryVariants.all { variant ->
-        def productFlavor = ""
-        variant.productFlavors.each {
-            productFlavor += "${it.name.capitalize()}"
-        }
-        def buildType = "${variant.buildType.name.capitalize()}"
-        if (variant.buildType.name != 'withoutLib') {
-            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
-        }
-
-        // For unit tests.
-        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
-    }
+    android.sourceSets.debug.jniLibs.srcDirs = android.sourceSets.main.jniLibs.srcDirs
+    android.sourceSets.release.jniLibs.srcDirs = android.sourceSets.main.jniLibs.srcDirs
+    android.sourceSets.main.jniLibs.srcDirs = []
 }
 
 cargo {
@@ -95,29 +80,13 @@ cargo {
 
     libname = 'glean_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'arm',
-        'arm64',
-        'x86',
-        'x86_64',
-    ]
+    targets = rootProject.ext.rustTargets
 
-    // Build for the "host" platform
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        targets.push('win32-x86-64-msvc')
-    } else if (Os.isFamily(Os.FAMILY_MAC)) {
-        targets.push('darwin')
-    } else if (Os.isFamily(Os.FAMILY_UNIX)) {
-        targets.push('linux-x86-64')
-    }
-
-    // Perform release builds (which should have debug info, due to
-    // `debug = true` in Cargo.toml).
-    profile = "release"
+    profile = rootProject.ext.nonMegazordProfile
 
     exec = rootProject.ext.cargoExec
+
+    extraCargoBuildArguments = rootProject.ext.extraCargoBuildArguments
 }
 
 configurations {
@@ -146,10 +115,10 @@ android {
 }
 
 dependencies {
-    jnaForTest 'net.java.dev.jna:jna:4.5.2@jar'
+    jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
+    implementation "net.java.dev.jna:jna:$jna_version@aar"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'net.java.dev.jna:jna:4.5.2@aar'
 
     implementation "androidx.annotation:annotation:1.0.2"
 
@@ -168,6 +137,23 @@ dependencies {
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}
+
+afterEvaluate {
+    // The `cargoBuild` task isn't available until after evaluation.
+    android.libraryVariants.all { variant ->
+        def productFlavor = ""
+        variant.productFlavors.each {
+            productFlavor += "${it.name.capitalize()}"
+        }
+        def buildType = "${variant.buildType.name.capitalize()}"
+        if (variant.buildType.name != 'withoutLib') {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
+
+        // For unit tests.
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+    }
 }
 
 //apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'


### PR DESCRIPTION
This applies the changes from [c40e2cc in mozilla/application-services](https://github.com/mozilla/application-services/tree/c40e2ccb422cf4af9ffdf095149cec34de1d4bef) to our repo, with minimal tweaks due to the different directory layout and the glean parsers integration.

**Note** - klint and detekt are currently not invoked on CI, even though they can run manually, because we have dozens of errors :)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
