### PR TITLE
Add (empty) detekt config to make detekt happy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,6 @@ detekt {
     toolVersion = "1.0.0-RC14"
     input = files("${projectDir}/glean-core", "${projectDir}/samples/android", "buildSrc")
     filters = ".*test.*,.*/resources/.*,.*/tmp/.*,.*/build/.*"
-    config = files("${projectDir}/.detekt.yml")
     failFast = false
     reports {
         xml.enabled = false


### PR DESCRIPTION
`./gradlew detekt` didn't run for me without that file locally.

Here's application-services file: https://github.com/mozilla/application-services/blob/377c1580deb21b9e17f8ba6d36e2565bab0891a5/.detekt.yml

It's 500 lines long. I don't like that and I don't understand roughly 499 of those lines, so I opted for having the most minimal working config instead.

Edit: after more testing and chatting I removed the config file from the build.gradle. We can add it back when we _do_ need to change the config.